### PR TITLE
Minor fix to Vitalik's lmd ghost.

### DIFF
--- a/eth2/fork_choice/choices/vitalik/vitalik.go
+++ b/eth2/fork_choice/choices/vitalik/vitalik.go
@@ -205,7 +205,7 @@ func (gh *VitaliksOptimizedLMDGhost) HeadFn() *dag.DagNode {
 		// But not the very end, as this will likely not have a majority vote.
 		step := gh.getPowerOf2Below(gh.maxKnownHeight - head.Height) / 2
 		for step > 0 {
-			possibleClearWinner := gh.getClearWinner(latestVotes, (head.Height + gh.maxKnownHeight)/2)
+			possibleClearWinner := gh.getClearWinner(latestVotes, (head.Height - (head.Height % step) + step)
 			if possibleClearWinner != nil {
 				head = possibleClearWinner
 				break


### PR DESCRIPTION
I think this is a slight error in your implementation of Vitalik's algorithm. It seems the loop is running the same `getClearWinner` in each iteration. 

This may help if you are benching all the algorithms.